### PR TITLE
A couple of minor tweaks from a PRO DJANGO USER

### DIFF
--- a/jokeregistryweb/jokes/tests.py
+++ b/jokeregistryweb/jokes/tests.py
@@ -9,10 +9,16 @@ import pytz
 import responses
 from unittest.mock import MagicMock
 
+
 class JokeTestCase(TestCase):
+
     @override_settings(TWITTER_BEARER_TOKEN='no-op')
     def test_twitter_url_submit(self):
         factory = RequestFactory()
+        request = factory.get('/jokes/load')
+        response = load(request)
+        self.assertEquals(response.status_code, 405)
+
         request = factory.post(
             '/jokes/load',
             {'url': 'https://twitter.com/cregslist/status/651932161755475968'})

--- a/jokeregistryweb/jokes/views.py
+++ b/jokeregistryweb/jokes/views.py
@@ -1,12 +1,13 @@
 import json
 
-from django.http import HttpResponseNotAllowed
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
+from django.views.decorators.http import require_http_methods
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
 
 from .models import Joke
+
 
 class JokeListView(ListView):
 
@@ -24,9 +25,8 @@ def new(request):
     return TemplateResponse(request, 'new_joke.html')
 
 
+@require_http_methods(['POST'])
 def load(request):
-    if request.META['REQUEST_METHOD'] != 'POST':
-        return HttpResponseNotAllowed(['POST'])
 
     if request.META['CONTENT_TYPE'] == 'application/json':
         # load JSON

--- a/jokeregistryweb/urls.py
+++ b/jokeregistryweb/urls.py
@@ -15,12 +15,13 @@ Including another URLconf
     3. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
 from django.conf.urls import url, include
+from django.contrib.auth.views import logout
 
 from .views import index
 
 urlpatterns = [
     url('', include('social.apps.django_app.urls', namespace='social')),
-    url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
+    url(r'^logout/$', logout, {'next_page': '/'}),
     url(r'^claims/', include('jokeregistryweb.claims.urls')),
     url(r'^jokes/', include('jokeregistryweb.jokes.urls')),
     url(r'^$', index),


### PR DESCRIPTION
We get a deprecation warning from using a string as a param to `url()`, and there's a decorator that takes care of 405s. :-*
